### PR TITLE
fix joomla Registry update bug

### DIFF
--- a/Sqlsync/Config.php
+++ b/Sqlsync/Config.php
@@ -28,6 +28,7 @@ class Config extends Registry
 	{
 		parent::__construct($data);
 
+		// Workaround to fix Joomla 3.6.4 bug, @see https://github.com/ventoviro/rad-development-bundle/pull/10
 		$this->initialized = true;
 	}
 

--- a/Sqlsync/Config.php
+++ b/Sqlsync/Config.php
@@ -18,6 +18,20 @@ use DevelopmentBundle\Sqlsync\Registry\Format\Json;
 class Config extends Registry
 {
 	/**
+	 * Constructor
+	 *
+	 * @param   mixed $data The data to bind to the new Registry object.
+	 *
+	 * @since   1.0
+	 */
+	public function __construct($data = null)
+	{
+		parent::__construct($data);
+
+		$this->initialized = true;
+	}
+
+	/**
 	 * Get a namespace in a given string format
 	 *
 	 * @param   string  $format   Format to return the string in


### PR DESCRIPTION
因為joomla更新在loadString新增initialized check導致getConfig loadFile兩次會爆掉
![20161215-160823](https://cloud.githubusercontent.com/assets/3166468/21216291/d4bd67de-c2e0-11e6-8d6e-66f53b3121fb.png)
